### PR TITLE
Update view_helper.rb

### DIFF
--- a/lib/gmap_coordinates_picker/view_helper.rb
+++ b/lib/gmap_coordinates_picker/view_helper.rb
@@ -7,7 +7,7 @@ module GmapCoordinatesPicker #:nodoc
         lng_column = options[:gmap_conf][:lng_column]
         lat_column_value = options[:object].present? ? options[:object].send(lat_column) : default_coordinates[0]
         lng_column_value = options[:object].present? ? options[:object].send(lng_column) : default_coordinates[1]
-        prefix = options[:object].present? ? options[:object].class.name.downcase : "gmap_coordinate_picker"
+        prefix = options[:object].present? ? options[:object].class.name.underscore : "gmap_coordinate_picker"
         lat_dom_id = "#{prefix}_#{lat_column}"
         lng_dom_id = "#{prefix}_#{lng_column}"
       end


### PR DESCRIPTION
when model name is more than one word method downcase failed to produce right form field name so it does not update the lng and lat fields with the new coordinates 
ex BabySitter 
it should be baby_sitter_longitude and baby_sitter_latitude
but gem produce babysitter_longitude and babysitter_latitude 

i think the right method is underscore not downcase 
when trying to find prefix js variable
